### PR TITLE
Move the AutoExit branch into DatabaseModels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 # Ignore building files
 /bin/*
 /obj/*
+/.vs

--- a/Controller/HomeController.cs
+++ b/Controller/HomeController.cs
@@ -30,5 +30,28 @@ namespace Construction_Personal_Tracking_System.Controller {
             string jsonToken = JsonConvert.SerializeObject(token);
             return Ok(token);
         }
+
+        /**
+         * Check if the user has made entry twice into different sectors, 
+         * then return a flag that they should be automatically exited from
+         * last second sector.
+         * 
+         * If true, they should be exited from that sector
+         */
+        [HttpGet]
+        public private bool IsAutoExit([FromBody] UserInfo userInfo) {
+            // TO DO
+            return false;
+        }
+
+        /**
+         * Check if the user's last visit is an exit or entry.
+         * If true, it's an entry. If false, then it's an exit
+         */
+        [HttpGet]
+        public private bool IsEntry([FromBody] UserInfo userInfo) {
+            // TO DO
+            return false;
+        }
     }
 }


### PR DESCRIPTION
, as it requires the models and database context to exist first, so that automatic exit flag can be raised when necessary.